### PR TITLE
Support multiple (audio+video) streams in demo janus client

### DIFF
--- a/docs/h264.md
+++ b/docs/h264.md
@@ -78,6 +78,14 @@ memsink: {
 EOF
 ```
 
+For audio, also add the following to `/opt/janus/lib/janus/configs/janus.plugin.ustreamer.jcfg`:
+```
+audio: {
+    device = "hw:1"
+    tc358743 = "/dev/video0"
+}
+```
+
 ### Start µStreamer and the Janus WebRTC Server
 
 For µStreamer to share the video stream with the µStreamer Janus plugin, µStreamer must run with the following command-line flags:
@@ -111,13 +119,13 @@ The client-side JavaScript application uses the following control flow:
 1. The client instructs the Janus server to attach the µStreamer Janus plugin.
 1. On success, the client obtains a plugin handle through which it can send requests directly to the µStreamer Janus plugin. The client processes responses via the `attach` callbacks:
    - `onmessage` for general messages
-   - `onremotetrack` for the H.264 video stream
+   - `onremotetrack` for the H.264 video stream and (maybe) Opus audio stream
 1. The client issues a `watch` request to the µStreamer Janus plugin, which initiates the H.264 stream in the plugin itself.
    - It takes a few seconds for uStreamer's video stream to become available to Janus. The first `watch` request may fail, so the client must retry the `watch` request.
 1. The client and server negotiate the underlying parameters of the WebRTC session. This procedure is called JavaScript Session Establishment Protocol (JSEP). The server makes a `jsepOffer` to the client, and the client responds with a `jsepAnswer`.
 1. The client issues a `start` request to the µStreamer Janus plugin to indicate that the client wants to begin consuming the video stream.
-1. The µStreamer Janus plugin delivers the H.264 video stream to the client via WebRTC.
-1. The Janus client library invokes the `onremotetrack` callback. The client attaches the video stream to the `<video>` element, rendering the video stream in the browser window.
+1. The µStreamer Janus plugin delivers the H.264 video stream and (maybe) Opus audio stream to the client via WebRTC.
+1. The Janus client library invokes the `onremotetrack` callback. The client attaches the video stream to the `<video>` element, rendering the video stream in the browser window. This is (maybe) repeated to add an audio track to the `<video>` element.
 
 ### Sample Code
 
@@ -176,7 +184,7 @@ The client-side JavaScript application uses the following control flow:
         // successfully.
         success: function (pluginHandle) {
           uStreamerPluginHandle = pluginHandle;
-          // Instruct the µStreamer Janus plugin to initiate the video stream.
+          // Instruct the µStreamer Janus plugin to initiate streaming.
           uStreamerPluginHandle.send({ message: { request: "watch" } });
         },
 
@@ -211,14 +219,14 @@ The client-side JavaScript application uses the following control flow:
           }
         },
 
-        // Callback function, for when the video stream arrives.
+        // Callback function, for when a media stream arrives.
         onremotetrack: function (mediaStreamTrack, mediaId, isAdded) {
           if (isAdded) {
             // Attach the received media track to the video element. Cloning the
             // mediaStreamTrack creates a new object with a distinct, globally
             // unique stream identifier.
             const videoElement = document.getElementById("webrtc-output");
-            if (videoElement.srcObject == null)
+            if (videoElement.srcObject === null)
             {
               videoElement.srcObject = new MediaStream();
             }

--- a/docs/h264.md
+++ b/docs/h264.md
@@ -218,9 +218,11 @@ The client-side JavaScript application uses the following control flow:
             // mediaStreamTrack creates a new object with a distinct, globally
             // unique stream identifier.
             const videoElement = document.getElementById("webrtc-output");
-            const stream = new MediaStream();
-            stream.addTrack(mediaStreamTrack.clone());
-            videoElement.srcObject = stream;
+            if (videoElement.srcObject == null)
+            {
+              videoElement.srcObject = new MediaStream();
+            }
+            videoElement.srcObject.addTrack(mediaStreamTrack.clone());
           }
         },
       });


### PR DESCRIPTION
When connecting to a janus server with multiple streams (video stream + audio stream) we need to add all (both) to the video srcObject. Previously we only attached the most-recently-advertised stream. This meant we would get audio or video but not both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/ustreamer/4)
<!-- Reviewable:end -->
